### PR TITLE
Update app.json : switch heroku-postgresql add-on from 9.5 to 9.6

### DIFF
--- a/app.json
+++ b/app.json
@@ -129,7 +129,7 @@
   "addons": [{
     "plan": "heroku-postgresql",
     "options": {
-      "version": "9.5"
+      "version": "9.6"
     }
   }],
   "buildpacks": [{


### PR DESCRIPTION
Version 9.5 has been deprecated...